### PR TITLE
[Deployment] v0.9.8

### DIFF
--- a/app/src/main/java/com/delivalue/tidings/domain/comment/service/CommentService.java
+++ b/app/src/main/java/com/delivalue/tidings/domain/comment/service/CommentService.java
@@ -55,7 +55,7 @@ public class CommentService {
     public List<CommentResponse> getUserCommentByCursor(String userId, LocalDateTime cursorTime) {
         Member member = this.memberRepository.findByPublicId(userId);
         if(member == null) throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-        if(member.getDeletedAt() != null) throw new ResponseStatusException(HttpStatus.GONE);
+        if(member.getDeletedAt() != null || member.getBannedAt() != null) throw new ResponseStatusException(HttpStatus.GONE);
 
         Query query = new Query();
         query.addCriteria(
@@ -77,6 +77,7 @@ public class CommentService {
         if(requestMember.isEmpty()) throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
 
         Member member = requestMember.get();
+        if(member.getBannedAt() != null) throw new ResponseStatusException(HttpStatus.FORBIDDEN, member.getBanReason() + " 사유로 차단된 사용자입니다.");
 
         Comment.CommentBuilder commentBuilder = Comment.builder();
         commentBuilder
@@ -115,6 +116,7 @@ public class CommentService {
         if(requestMember.isEmpty()) throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
 
         Member member = requestMember.get();
+        if(member.getBannedAt() != null) throw new ResponseStatusException(HttpStatus.FORBIDDEN, member.getBanReason() + " 사유로 차단된 사용자입니다.");
 
         Comment.CommentBuilder commentBuilder = Comment.builder();
         commentBuilder

--- a/app/src/main/java/com/delivalue/tidings/domain/data/entity/Member.java
+++ b/app/src/main/java/com/delivalue/tidings/domain/data/entity/Member.java
@@ -42,4 +42,10 @@ public class Member {
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
+
+    @Column(name = "banned_at")
+    private LocalDateTime bannedAt;
+
+    @Column(name = "ban_reason")
+    private String banReason;
 }

--- a/app/src/main/java/com/delivalue/tidings/domain/data/service/StorageService.java
+++ b/app/src/main/java/com/delivalue/tidings/domain/data/service/StorageService.java
@@ -4,7 +4,9 @@ import com.delivalue.tidings.domain.data.entity.Member;
 import com.delivalue.tidings.domain.data.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
@@ -27,6 +29,8 @@ public class StorageService {
     public URL getProfilePresignedUploadUrl(String internalId, String contentType) {
         Optional<Member> member = this.memberRepository.findById(internalId);
         if(member.isEmpty()) return null;
+        if(member.get().getBannedAt() != null) throw new ResponseStatusException(HttpStatus.FORBIDDEN, member.get().getBanReason() + " 사유로 차단된 사용자입니다.");
+
 
         String publicId = member.get().getPublicId();
         String uuid = UUID.randomUUID().toString();
@@ -38,6 +42,8 @@ public class StorageService {
     public URL getPostMediaPresignedUploadUrl(String internalId, String contentType) {
         Optional<Member> member = this.memberRepository.findById(internalId);
         if(member.isEmpty()) return null;
+        if(member.get().getBannedAt() != null) throw new ResponseStatusException(HttpStatus.FORBIDDEN, member.get().getBanReason() + " 사유로 차단된 사용자입니다.");
+
 
         String publicId = member.get().getPublicId();
         String uuid = UUID.randomUUID().toString();

--- a/app/src/main/java/com/delivalue/tidings/domain/profile/service/ProfileService.java
+++ b/app/src/main/java/com/delivalue/tidings/domain/profile/service/ProfileService.java
@@ -35,6 +35,7 @@ public class ProfileService {
 
         Member member = resultMember.get();
         if(member.getDeletedAt() != null) throw new ResponseStatusException(HttpStatus.GONE);
+        if(member.getBannedAt() != null) throw new ResponseStatusException(HttpStatus.FORBIDDEN, member.getBanReason() + " 사유로 차단된 사용자입니다.");
 
         return new ProfileResponse(member);
     }
@@ -42,7 +43,7 @@ public class ProfileService {
     public ProfileResponse getProfileByPublicId(String publicId) {
         Member member = this.memberRepository.findByPublicId(publicId);
         if(member == null) throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-        if(member.getDeletedAt() != null) throw new ResponseStatusException(HttpStatus.GONE);
+        if(member.getDeletedAt() != null || member.getBannedAt() != null) throw new ResponseStatusException(HttpStatus.GONE);
 
         return new ProfileResponse(member);
     }
@@ -55,7 +56,9 @@ public class ProfileService {
     public void updateProfile(ProfileUpdateRequest profileUpdateRequest) {
         Optional<Member> updateMember = this.memberRepository.findById(profileUpdateRequest.getId());
         if(updateMember.isEmpty()) throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
+
         Member member = updateMember.get();
+        if(member.getBannedAt() != null) throw new ResponseStatusException(HttpStatus.FORBIDDEN, member.getBanReason() + " 사유로 차단된 사용자입니다.");
 
         boolean needSpread = false;
         Update spreadUpdate = new Update();


### PR DESCRIPTION

## 기능이 추가되었습니다.

차단된 사용자가 특정 메서드를 요구할 때 403 Forbidde을 반환하도록 변경하였습니다.

Member Entity의 bannedAt과 banReason 필드를 추가하였습니다.

## 기능이 변경되었습니다.

최근 포스트를 조회할 때 스크랩된 포스트를 제외하고 가져오도록 변경하였습니다.

포스트를 스크랩할 때 생성 시간을 기존 스크랩 대상 포스트의 생성 시점이 아닌, 스크랩을 수행하는 시점으로 설정되도록 변경하였습니다.